### PR TITLE
Chore: Added context for fetching wsdl definitions 

### DIFF
--- a/soap.go
+++ b/soap.go
@@ -126,25 +126,30 @@ func (c *Client) CallByStruct(s RequestStruct) (res *Response, err error) {
 	return c.CallByStructContext(context.Background(), s)
 }
 
-func (c *Client) waitAndRefreshDefinitions(d time.Duration) {
+func (c *Client) waitAndRefreshDefinitions(ctx context.Context, d time.Duration) {
 	for {
 		time.Sleep(d)
 		c.onRequest.Wait()
 		c.onDefinitionsRefresh.Add(1)
-		c.initWsdl()
+		c.initWsdl(ctx)
 		c.onDefinitionsRefresh.Done()
 	}
 }
 
-func (c *Client) initWsdl() {
-	c.Definitions, c.definitionsErr = getWsdlDefinitions(c.wsdl, c.HTTPClient)
+func (c *Client) initWsdl(ctx context.Context) {
+	c.Definitions, c.definitionsErr = getWsdlDefinitions(ctx, c.wsdl, c.HTTPClient)
 	if c.definitionsErr == nil {
 		c.URL = strings.TrimSuffix(c.Definitions.TargetNamespace, "/")
 	}
 }
 
-// SetWSDL set WSDL url
+// SetWSDL wraps SetWSDLWithContext using context.Background()
 func (c *Client) SetWSDL(wsdl string) {
+	c.SetWSDLWithContext(context.Background(), wsdl)
+}
+
+// SetWSDLWithContext sets WSDL url
+func (c *Client) SetWSDLWithContext(ctx context.Context, wsdl string) {
 	c.onRequest.Wait()
 	c.onDefinitionsRefresh.Wait()
 	c.onRequest.Add(1)
@@ -152,7 +157,7 @@ func (c *Client) SetWSDL(wsdl string) {
 	defer c.onRequest.Done()
 	defer c.onDefinitionsRefresh.Done()
 	c.wsdl = wsdl
-	c.initWsdl()
+	c.initWsdl(ctx)
 }
 
 // Do Process Soap Request
@@ -162,10 +167,10 @@ func (c *Client) Do(ctx context.Context, req *Request) (res *Response, err error
 	defer c.onRequest.Done()
 
 	c.once.Do(func() {
-		c.initWsdl()
+		c.initWsdl(ctx)
 		// 15 minute to prevent abuse.
 		if c.RefreshDefinitionsAfter >= 15*time.Minute {
-			go c.waitAndRefreshDefinitions(c.RefreshDefinitionsAfter)
+			go c.waitAndRefreshDefinitions(ctx, c.RefreshDefinitionsAfter)
 		}
 	})
 

--- a/wsdl.go
+++ b/wsdl.go
@@ -1,6 +1,7 @@
 package gosoap
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -157,7 +158,7 @@ type xsdMaxInclusive struct {
 	Value string `xml:"value,attr"`
 }
 
-func getWsdlBody(u string, c *http.Client) (reader io.ReadCloser, err error) {
+func getWsdlBody(ctx context.Context, u string, c *http.Client) (reader io.ReadCloser, err error) {
 	parse, err := url.Parse(u)
 	if err != nil {
 		return nil, err
@@ -172,7 +173,13 @@ func getWsdlBody(u string, c *http.Client) (reader io.ReadCloser, err error) {
 	if c == nil {
 		c = &http.Client{}
 	}
-	r, err := c.Get(u)
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := c.Do(request)
 	if err != nil {
 		return nil, err
 	}
@@ -180,8 +187,8 @@ func getWsdlBody(u string, c *http.Client) (reader io.ReadCloser, err error) {
 }
 
 // getWsdlDefinitions sent request to the wsdl url and set definitions on struct
-func getWsdlDefinitions(u string, c *http.Client) (wsdl *wsdlDefinitions, err error) {
-	reader, err := getWsdlBody(u, c)
+func getWsdlDefinitions(ctx context.Context, u string, c *http.Client) (wsdl *wsdlDefinitions, err error) {
+	reader, err := getWsdlBody(ctx, u, c)
 	if err != nil {
 		return nil, err
 	}

--- a/wsdl_test.go
+++ b/wsdl_test.go
@@ -1,6 +1,7 @@
 package gosoap
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"runtime"
@@ -60,7 +61,7 @@ func Test_getWsdlBody(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := getWsdlBody(tt.args.u, nil)
+			_, err := getWsdlBody(context.TODO(), tt.args.u, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getwsdlBody() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
## Description:

### What does this PR do?
This PR updates existing methods to accept a context parameter for fetching WSDL definitions. The methods `initWsdl()`, `getWsdlDefinitions()`, and `getWsdlBody()` have been modified to include a context parameter.

The `initWsdl()` is called by three other methods: `waitAndRefreshDefinitions()`, `SetWSDL()` and `c.Do()`.  The `waitAndRefreshDefinitions()` method has been updated to accept a context argument.  Since the `SetWSDL` is a public method, I have introduced a new method called `SetWSDLWithContext`, which accepts the context argument. The existing `SetWSDL` method has been updated to internally call `SetWSDLWithContext`.

The `c.Do()` method already accepts context parameters in its arguments, so it remains unchanged.